### PR TITLE
Increased testing for binSeg function

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: changepoint.cov
 Title: Implementation of Covariance Changepoint Methods
-Version: 0.2.0
+Version: 0.2.1
 Authors@R: 
     person(given = "Thomas",
            family = "Grundy",

--- a/R/cptCUSUM.R
+++ b/R/cptCUSUM.R
@@ -47,10 +47,10 @@ cptCUSUM <- function(X,threshold='Asymptotic',numCpts='AMOC',msl=2*ncol(X),LRCov
 		T <- mean(testStat,na.rm=TRUE)
 		if(T>thresholdValue){
 			cpts <- c(which.max(testStat),n)
-			cptsSig <- data.frame('cpts'=cpts[1],'T'=T,'thresholdValue'=thresholdValue)
+			cptsSig <- data.frame('cpts'=cpts[1],'T'=T,'thresholdValue'=thresholdValue,'significant'=TRUE)
 		}else{
 			cpts <- c(n)
-			cptsSig <- data.frame('cpts'=which.max(testStat),'T'=T,'thresholdValue'=thresholdValue)
+			cptsSig <- data.frame('cpts'=which.max(testStat),'T'=T,'thresholdValue'=thresholdValue,'significant'=FALSE)
 		}
 	}else{
 		if(is.numeric(numCpts)){
@@ -59,8 +59,7 @@ cptCUSUM <- function(X,threshold='Asymptotic',numCpts='AMOC',msl=2*ncol(X),LRCov
 		}else{
 			cptsSig <- binSeg(X,method='CUSUM',msl=msl,threshold=threshold,thresholdValue=thresholdValue,m=-1,LRCov=LRCov)
 		}
-		cpts <- c(cptsSig$cpts,n)
-		cpts <- sort(cpts[!is.na(cpts)])
+		cpts <- c(cptsSig$cpts[cptsSig$significant],n)
 	}
 	if(Class==FALSE){
 		return(cpts)

--- a/R/cptRatio.R
+++ b/R/cptRatio.R
@@ -45,10 +45,10 @@ cptRatio <- function(X,threshold='Asymptotic',numCpts='AMOC',msl=2*ncol(X),thres
 		T <- max(testStat,na.rm=TRUE)
 		if(T>thresholdValue){
 			cpts <- c(which.max(testStat),n)
-			cptsSig <- data.frame('cpts'=cpts[1],'T'=T,'thresholdValue'=thresholdValue)
+			cptsSig <- data.frame('cpts'=cpts[1],'T'=T,'thresholdValue'=thresholdValue,'significant'=TRUE)
 		}else{
 			cpts <- c(n)
-			cptsSig <- data.frame('cpts'=which.max(testStat),'T'=T,'thresholdValue'=thresholdValue)
+			cptsSig <- data.frame('cpts'=which.max(testStat),'T'=T,'thresholdValue'=thresholdValue,'significant'=FALSE)
 		}
 	}else{
 		if(is.numeric(numCpts)){
@@ -57,8 +57,7 @@ cptRatio <- function(X,threshold='Asymptotic',numCpts='AMOC',msl=2*ncol(X),thres
 		}else{
 			cptsSig <- binSeg(X,method='RATIO',msl=msl,threshold=threshold,thresholdValue=thresholdValue,m=-1)
 		}
-		cpts <- c(cptsSig$cpts,n)
-		cpts <- sort(cpts[!is.na(cpts)])
+		cpts <- c(cptsSig$cpts[cptsSig$significant],n)
 	}
 	if(Class==FALSE){
 		return(cpts)

--- a/R/cptSubspace.R
+++ b/R/cptSubspace.R
@@ -61,10 +61,10 @@ cptSubspace <- function(X,q,threshold='PermTest',numCpts='AMOC',thresholdValue=0
 		}
 		if(T>thresholdValue){
 			cpts <- c(which.max(testStat),n)
-			cptsSig <- data.frame('cpts'=cpts[1],'T'=T,'thresholdValue'=thresholdValue)
+			cptsSig <- data.frame('cpts'=cpts[1],'T'=T,'thresholdValue'=thresholdValue,'significant'=TRUE)
 		}else{
 			cpts <- c(n)
-			cptsSig <- data.frame('cpts'=which.max(testStat),'T'=T,'thresholdValue'=thresholdValue)
+			cptsSig <- data.frame('cpts'=which.max(testStat),'T'=T,'thresholdValue'=thresholdValue,'significant'=FALSE)
 		}
 	}else{
 		if(is.numeric(numCpts)){
@@ -78,8 +78,7 @@ cptSubspace <- function(X,q,threshold='PermTest',numCpts='AMOC',thresholdValue=0
 				cptsSig <- binSeg(X,method='SUBSPACE',msl=msl,threshold=threshold,thresholdValue=thresholdValue,m=-1,q=q)
 			}
 		}
-		cpts <- c(cptsSig$cpts,n)
-		cpts <- sort(cpts[!is.na(cpts)])
+		cpts <- c(cptsSig$cpts[cptsSig$significant],n)
 	}
 	if(Class==FALSE){
 		return(cpts)

--- a/man/binSeg.Rd
+++ b/man/binSeg.Rd
@@ -8,8 +8,8 @@ binSeg(
   X,
   method,
   msl,
-  threshold,
-  thresholdValue,
+  threshold = "Manual",
+  thresholdValue = 0,
   m = -1,
   LRCov = "Bartlett",
   q = 1,
@@ -42,5 +42,5 @@ binSeg(
 A data frame containing the identified changepoints along with their test statistic and threshold they exceeded.
 }
 \description{
-This function estimates multiple covariance changepoints. NOTE no error checking is performed. This function is for developer use only.
+This function estimates multiple covariance changepoints. NOTE no argument type error checking is performed. This function is for developer use only.
 }

--- a/tests/testthat/test-binseg.R
+++ b/tests/testthat/test-binseg.R
@@ -1,0 +1,90 @@
+context('binSeg tests')
+library(changepoint.cov)
+
+##{{{ Data creation
+set.seed(1)
+data2Change <- wishartDataGeneration(n=200,p=5,tau=c(75,125))$data
+dataNull <- matrix(rnorm(200*5),ncol=5)
+
+data2ChangeSub <- subspaceDataGeneration(n=100,p=10,q=3,tau=c(30,60))$data
+dataNullSub <- subspaceDataGeneration(n=100,p=10,q=3,changeSize=0)$data
+##}}}
+
+##{{{ Subspace Functionality
+test_that("Basic subspace example works",{
+		  set.seed(1)
+		  ans1 <- binSeg(X=data2ChangeSub,q=3,method='Subspace',msl=10,threshold='PermTest',thresholdValue=0.05)
+		  expect_is(ans1,"data.frame")
+		  expect_equal(nrow(ans1),3)
+
+		  ans2 <- binSeg(X=data2ChangeSub,q=3,method='Subspace',msl=10,threshold='Manual',thresholdValue=5)
+		  expect_is(ans2,'data.frame')
+		  expect_equal(nrow(ans2),3)
+	
+		  ans3 <- binSeg(X=data2ChangeSub,q=3,method='Subspace',msl=10,m=2)
+		  expect_is(ans3,'data.frame')
+		  expect_equal(nrow(ans3),2)
+	
+		  ans4 <- binSeg(X=data2ChangeSub,q=3,method='Subspace',msl=10,m=4)
+		  expect_is(ans4,'data.frame')
+		  expect_equal(nrow(ans4),4)
+	
+		  set.seed(1)
+		  ans5 <- binSeg(X=dataNullSub,q=3,method='Subspace',msl=10,threshold='PermTest',thresholdValue,alpha=0.1)
+		  expect_is(ans5,"data.frame")
+		  expect_equal(nrow(ans5),1)
+		  expect_true(ans5$T<ans5$thresholdValue)
+		  expect_false(ans5$significant)
+})
+##}}}
+
+##{{{ Ratio Functionality
+test_that("Basic ratio example works",{
+		  ans1 <- binSeg(X=data2Change,method='Ratio',msl=20,thresholdValue=10)
+		  expect_is(ans1,"data.frame")
+		  expect_equal(nrow(ans1),3)
+
+		  ans2 <- binSeg(X=data2Change,method='Ratio',msl=20,m=2)
+		  expect_is(ans2,'data.frame')
+		  expect_equal(nrow(ans2),2)
+	
+		  ans3 <- binSeg(X=data2Change,method='Ratio',msl=20,m=4)
+		  expect_is(ans3,'data.frame')
+		  expect_equal(nrow(ans3),4)
+	
+		  ans4 <- binSeg(X=dataNull,method='Ratio',thresholdValue=20,msl=20)
+		  expect_is(ans4,"data.frame")
+		  expect_equal(nrow(ans4),1)
+		  expect_true(ans4$T<ans4$thresholdValue)
+		  expect_false(ans4$significant)
+})
+##}}}
+
+##{{{ CUSUM Functionality
+test_that("Basic cusum example works",{
+		  ans1 <- binSeg(X=data2Change,method='CUSUM',msl=20,thresholdValue=3)
+		  expect_is(ans1,"data.frame")
+		  expect_equal(nrow(ans1),3)
+
+		  ans2 <- binSeg(X=data2Change,method='CUSUM',msl=20,m=2)
+		  expect_is(ans2,'data.frame')
+		  expect_equal(nrow(ans2),2)
+	
+		  ans3 <- binSeg(X=data2Change,method='CUSUM',msl=20,m=4)
+		  expect_is(ans3,'data.frame')
+		  expect_equal(nrow(ans3),4)
+	
+		  ans4 <- binSeg(X=dataNull,method='CUSUM',thresholdValue=20,msl=20)
+		  expect_is(ans4,"data.frame")
+		  expect_equal(nrow(ans4),1)
+		  expect_true(ans4$T<ans4$thresholdValue)
+		  expect_false(ans4$significant)
+})
+##}}}
+
+##{{{ Minimum segment length requirements
+test_that("Minimum segment length requirements trigger warnings and errors",{
+		  expect_warning(binSeg(X=data2ChangeSub,q=3,method='Subspace',msl=25,m=10),"Cannot allocate 10 changepoints due to minimum segment length restrictions",fixed=TRUE)
+		  expect_error(binSeg(X=data2Change,q=3,method='Subspace',msl=1000,m=1),"Minimum segment length should be a single integer between p and n/2")
+})
+##}}}

--- a/tests/testthat/test-cusum.R
+++ b/tests/testthat/test-cusum.R
@@ -4,6 +4,7 @@ library(changepoint.cov)
 ##{{{ Data Creation
 set.seed(1)
 dataAMOC <- wishartDataGeneration(n=100,p=3,tau=50)$data
+data2Change <- wishartDataGeneration(n=200,p=3,tau=c(60,120))$data
 ##}}}
 
 ##{{{ Basic Functionality
@@ -48,8 +49,8 @@ test_that("Threshold type is correct",{
 
 test_that("Number of changepoints is correct",{
 		  expect_is(cptCUSUM(dataAMOC,numCpts='AMOC'),"cptCovariance")
-		  expect_is(cptCUSUM(dataAMOC,numCpts='BinSeg'),"cptCovariance")
-		  expect_is(cptCUSUM(dataAMOC,numCpts=1),"cptCovariance")
+		  expect_is(cptCUSUM(data2Change,numCpts='BinSeg'),"cptCovariance")
+		  expect_is(cptCUSUM(data2Change,numCpts=2),"cptCovariance")
 
 		  expect_error(cptCUSUM(dataAMOC,numCpts='AMC'),"numCpts not identified: see ?cptCov for valid entries to numCpts",fixed=TRUE)
 		  expect_error(cptCUSUM(dataAMOC,numCpts=TRUE),"numCpts not identified: see ?cptCov for valid entries to numCpts",fixed=TRUE)

--- a/tests/testthat/test-ratio.R
+++ b/tests/testthat/test-ratio.R
@@ -4,8 +4,8 @@ library(changepoint.cov)
 ##{{{ Data Creation
 set.seed(1)
 dataAMOC <- wishartDataGeneration(n=200,p=5,tau=50)$data
-set.seed(1)
 dataNull <- matrix(rnorm(100*3),ncol=3)
+data2Change <- wishartDataGeneration(n=300,p=30,tau=c(100,200))$data
 ##}}}
 
 ##{{{ Basic Functionality
@@ -50,8 +50,8 @@ test_that("Threshold type is correct",{
 
 test_that("Number of changepoints is correct",{
 		  expect_is(cptRatio(dataAMOC,numCpts='AMOC'),"cptCovariance")
-		  expect_is(cptRatio(dataAMOC,numCpts='BinSeg'),"cptCovariance")
-		  expect_is(cptRatio(dataAMOC,numCpts=1),"cptCovariance")
+		  expect_is(cptRatio(data2Change,numCpts='BinSeg'),"cptCovariance")
+		  expect_is(cptRatio(data2Change,numCpts=2),"cptCovariance")
 
 		  expect_error(cptRatio(dataAMOC,numCpts='AMC'),"numCpts not identified: see ?cptCov for valid entries to numCpts",fixed=TRUE)
 		  expect_error(cptRatio(dataAMOC,numCpts=TRUE),"numCpts not identified: see ?cptCov for valid entries to numCpts",fixed=TRUE)

--- a/tests/testthat/test-subspace.R
+++ b/tests/testthat/test-subspace.R
@@ -5,6 +5,7 @@ library(changepoint.cov)
 set.seed(1)
 dataAMOC <- subspaceDataGeneration(n=100,p=20,q=5,tau=50,changeSize=0.5*sqrt(5),nvar=0.05,svar=1)$data
 dataNull <- subspaceDataGeneration(n=100,p=20,q=5,tau=100,changeSize=0)$data
+data2Change <- subspaceDataGeneration(n=100,p=10,q=3,tau=c(30,60))$data
 
 ##}}}
 
@@ -75,8 +76,8 @@ test_that("Threshold type is correct",{
 
 test_that("Number of changepoints is correct",{
 		  expect_is(cptSubspace(dataAMOC,q=5,numCpts='AMOC',threshold='Manual',thresholdValue=10),"cptCovariance")
-		  expect_is(cptSubspace(dataAMOC,q=5,numCpts='BinSeg',threshold='Manual',thresholdValue=10),"cptCovariance")
-		  expect_is(cptSubspace(dataAMOC,q=5,numCpts=1,threshold='Manual',thresholdValue=10),"cptCovariance")
+		  expect_is(cptSubspace(data2Change,q=5,numCpts='BinSeg',threshold='Manual',thresholdValue=10),"cptCovariance")
+		  expect_is(cptSubspace(data2Change,q=5,numCpts=2,threshold='Manual',thresholdValue=10),"cptCovariance")
 
 		  expect_error(cptSubspace(dataAMOC,q=5,numCpts='AMC'),"numCpts not identified: see ?cptSubspace for valid entries to numCpts",fixed=TRUE)
 		  expect_error(cptSubspace(dataAMOC,q=5,numCpts=TRUE),"numCpts not identified: see ?cptSubspace for valid entries to numCpts",fixed=TRUE)


### PR DESCRIPTION
binSeg function now has its own testing file and produces a better data
frame with a column stating if the changepoint is significant or not.
Additionally, some msl error and warning traps have been added for user
specified number of changepoints that are too high and too large msl's.
The cptsSig data frame is not exported in the class yet - see next
update.